### PR TITLE
implement Issue1 country info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,6 @@ script_template_3.py
 test_template_3.py
 cover
 ~$*.docx
+
+# project-specific
+data/cache

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A python package for working with data in the Linked Places Format (LPF)
 
+# install and config
+
+- For functions involving the Geonames API, the environment variable `GEONAMES_USER` must be set to a string that is a valid GeoNames username. In the absence of this environment variable, the "demo" username is used, which almost always results in a "denied" response from the API.
+
 ## Roadmap
 
 - [ ] Support all LPF complex objects with corresponding python classes, each with intuitive properties for accessing data.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
   # "python-slugify",
   "textnorm",
   #"validators",
+  "webiquette@git+https://github.com/isawnyu/webiquette.git"
 ]
 [project.urls]
 # "Homepage" = "https://github.com/pypa/sampleproject"

--- a/src/lpfgaz/lpf.py
+++ b/src/lpfgaz/lpf.py
@@ -10,9 +10,14 @@ Read LPF files
 """
 import json
 import logging
+from os import environ
 from pathlib import Path
+from requests import RequestException
+from requests.models import PreparedRequest
+from webiquette.webi import Webi
 
 logger = logging.getLogger(__name__)
+DEFAULT_HEADERS = {"User-Agent": "lpfgaz/0.1.0 (+https://github.com/isawnyu/lpfgaz)"}
 
 
 class LPFFeature:
@@ -20,11 +25,14 @@ class LPFFeature:
     Manage a Linked Places Format Feature
     """
 
-    def __init__(self, data: dict):
+    def __init__(self, data: dict, web_headers: dict = DEFAULT_HEADERS):
         """
         Initialize LPF Feature
         """
         self._data = data  # original Linked Places Format data
+        self._geonames_country_info = None
+        self._web_headers = web_headers
+        self._web_interfaces = dict()
 
     @property
     def ccodes(self) -> list:
@@ -39,6 +47,13 @@ class LPFFeature:
         Get the country codes of the LPF Feature
         """
         return self.ccodes
+
+    @property
+    def countries_geonames(self) -> dict:
+        """
+        Get the Geonames country info of the LPF Feature
+        """
+        return [self._get_country_geonames(ccode) for ccode in self.ccodes]
 
     @property
     def fclasses(self) -> list:
@@ -67,6 +82,40 @@ class LPFFeature:
         Get the title of the LPF Feature
         """
         return self._data["properties"]["title"]
+
+    def _fetch_country_geonames(self, ccode: str) -> dict:
+        """
+        Retrieve the Geonames country info for a given country code
+        """
+        url = "http://api.geonames.org/countryInfoJSON"
+        try:
+            w = self._web_interfaces["geonames"]
+        except KeyError:
+            w = Webi(netloc="api.geonames.org", headers=self._web_headers)
+            self._web_interfaces["geonames"] = w
+        params = {"country": ccode, "username": environ.get("GEONAMES_USER", "demo")}
+        req = PreparedRequest()
+        req.prepare_url(url, params)
+        try:
+            response = w.get(req.url)
+            response.raise_for_status()
+        except RequestException as e:
+            logger.error(f"Error fetching Geonames country info for {ccode}: {e}")
+            return None
+        return response.json()
+
+    def _get_country_geonames(self, ccode: str) -> dict:
+        """
+        Return the Geonames country info for a given country code
+        """
+        if self._geonames_country_info is None:
+            self._geonames_country_info = {}
+        try:
+            info = self._geonames_country_info[ccode]
+        except KeyError:
+            info = self._fetch_country_geonames(ccode)
+            self._geonames_country_info[ccode] = info
+        return info
 
 
 class LPFFeatureCollection:

--- a/src/lpfgaz/lpf.py
+++ b/src/lpfgaz/lpf.py
@@ -77,6 +77,15 @@ class LPFFeature:
         """
         return self._data["@id"]
 
+    def is_valid_ccode(self, ccode: str) -> bool:
+        """
+        Check if a country code is valid
+        """
+        info = self._get_country_geonames(ccode)
+        if info is None:
+            return False
+        return True
+
     @property
     def title(self) -> str:
         """
@@ -119,8 +128,16 @@ class LPFFeature:
         try:
             info = self._geonames_country_info[ccode]
         except KeyError:
-            info = self._fetch_country_geonames(ccode)[0]
-            self._geonames_country_info[ccode] = info
+            info_list = self._fetch_country_geonames(ccode)
+            if len(info_list) == 0:
+                return None
+            elif len(info_list) == 1:
+                info = info_list[0]
+                self._geonames_country_info[ccode] = info
+            else:
+                raise RuntimeError(
+                    f"Multiple country info records found for {ccode}: {pformat(info_list, indent=4)}"
+                )
         return info
 
 

--- a/src/lpfgaz/lpf.py
+++ b/src/lpfgaz/lpf.py
@@ -54,7 +54,7 @@ class LPFFeature:
         """
         Get the Geonames country info of the LPF Feature
         """
-        return [self._get_country_geonames(ccode) for ccode in self.ccodes]
+        return {ccode: self._get_country_geonames(ccode) for ccode in self.ccodes}
 
     @property
     def fclasses(self) -> list:

--- a/tests/test_lpf.py
+++ b/tests/test_lpf.py
@@ -8,9 +8,11 @@
 """
 Test the lpfgaz.lpf module
 """
+from lpfgaz.lpf import LPFFeature, LPFFeatureCollection
+import logging
+from pprint import pformat
 import pytest
 from pathlib import Path
-from lpfgaz.lpf import LPFFeature, LPFFeatureCollection
 
 test_data_path = Path("tests/data")
 example_lpf_file = test_data_path / "example_lpf.jsonld"
@@ -42,9 +44,7 @@ class TestLPFFeature:
     def test_countries_geonames(self, example_feature_data):
         # Test the countries_geonames property
         feature = LPFFeature(example_feature_data)
-        assert feature.countries_geonames == [
-            {"geonames_id": 2635167, "name": "United Kingdom"}
-        ]
+        assert feature.countries_geonames[0]["countryName"] == "United Kingdom"
 
 
 class TestLPFFeatureCollection:

--- a/tests/test_lpf.py
+++ b/tests/test_lpf.py
@@ -47,6 +47,12 @@ class TestLPFFeature:
         ccode = example_feature_data["properties"]["ccodes"][0]
         assert feature.countries_geonames[ccode]["countryName"] == "United Kingdom"
 
+    def test_is_valid_ccode(self):
+        # Test the is_valid_ccode method
+        feature = LPFFeature({})
+        assert feature.is_valid_ccode("GB")
+        assert not feature.is_valid_ccode("8675309")
+
 
 class TestLPFFeatureCollection:
 

--- a/tests/test_lpf.py
+++ b/tests/test_lpf.py
@@ -39,6 +39,13 @@ class TestLPFFeature:
         assert feature.fclasses == example_feature_data["properties"]["fclasses"]
         assert feature.feature_classes == example_feature_data["properties"]["fclasses"]
 
+    def test_countries_geonames(self, example_feature_data):
+        # Test the countries_geonames property
+        feature = LPFFeature(example_feature_data)
+        assert feature.countries_geonames == [
+            {"geonames_id": 2635167, "name": "United Kingdom"}
+        ]
+
 
 class TestLPFFeatureCollection:
 

--- a/tests/test_lpf.py
+++ b/tests/test_lpf.py
@@ -44,7 +44,8 @@ class TestLPFFeature:
     def test_countries_geonames(self, example_feature_data):
         # Test the countries_geonames property
         feature = LPFFeature(example_feature_data)
-        assert feature.countries_geonames[0]["countryName"] == "United Kingdom"
+        ccode = example_feature_data["properties"]["ccodes"][0]
+        assert feature.countries_geonames[ccode]["countryName"] == "United Kingdom"
 
 
 class TestLPFFeatureCollection:


### PR DESCRIPTION
This PR adds general web functionality via the webiquette package and uses it to pull country-related information from the GeoNames API. This information is used to provide country info for bare country codes and also for a utility method that validates country codes. 